### PR TITLE
Properly Escape User's Name in PusherChatWidget.js

### DIFF
--- a/src/js/PusherChatWidget.js
+++ b/src/js/PusherChatWidget.js
@@ -137,7 +137,7 @@ PusherChatWidget.prototype._sendChatMessage = function(data) {
       var image = $('<div class="pusher-chat-widget-current-user-image">' +
                       '<img src="' + imageInfo.url + '" width="32" height="32" />' +
                     '</div>');
-      var name = $('<div class="pusher-chat-widget-current-user-name">' + activity.actor.displayName + '</div>');
+      var name = $('<div class="pusher-chat-widget-current-user-name">' + activity.actor.displayName.replace(/\\/gi, '') + '</div>');
       var header = self._widget.find('.pusher-chat-widget-header');
       header.html(image).append(name);
     }
@@ -205,7 +205,7 @@ PusherChatWidget._buildListItem = function(activity) {
   
   var user = $('<div class="activity-row">' +
                 '<span class="user-name">' +
-                  '<a class="screen-name" title="' + activity.actor.displayName + '">' + activity.actor.displayName + '</a>' +
+                  '<a class="screen-name" title="' + activity.actor.displayName.replace(/\\/gi, '') + '">' + activity.actor.displayName.replace(/\\/gi, '') + '</a>' +
                   //'<span class="full-name">' + activity.actor.displayName + '</span>' +
                 '</span>' +
               '</div>');

--- a/src/js/PusherChatWidget.js
+++ b/src/js/PusherChatWidget.js
@@ -137,7 +137,7 @@ PusherChatWidget.prototype._sendChatMessage = function(data) {
       var image = $('<div class="pusher-chat-widget-current-user-image">' +
                       '<img src="' + imageInfo.url + '" width="32" height="32" />' +
                     '</div>');
-      var name = $('<div class="pusher-chat-widget-current-user-name">' + activity.actor.displayName.replace(/\\/gi, '') + '</div>');
+      var name = $('<div class="pusher-chat-widget-current-user-name">' + activity.actor.displayName.replace(/\\'/g, "'") + '</div>');
       var header = self._widget.find('.pusher-chat-widget-header');
       header.html(image).append(name);
     }
@@ -205,7 +205,7 @@ PusherChatWidget._buildListItem = function(activity) {
   
   var user = $('<div class="activity-row">' +
                 '<span class="user-name">' +
-                  '<a class="screen-name" title="' + activity.actor.displayName.replace(/\\/gi, '') + '">' + activity.actor.displayName.replace(/\\/gi, '') + '</a>' +
+                  '<a class="screen-name" title="' + activity.actor.displayName.replace(/\\'/g, "'") + '">' + activity.actor.displayName.replace(/\\'/g, "'") + '</a>' +
                   //'<span class="full-name">' + activity.actor.displayName + '</span>' +
                 '</span>' +
               '</div>');


### PR DESCRIPTION
Hello All,

Recently, while I was working on my project Collab.Center (https://github.com/Mulletfingers999/Collab.Center), which uses Pusher, I found that a user's name was not properly escaped in the Chat (https://github.com/Mulletfingers999/Collab.Center/issues/7). I edited PusherChatWidget.js myself to fix this. Once I found Pusher was open sourced, I created a pull request. This pull request  properly Escapes `activity.actor.displayName`. Previously, if the user's name was 'Liam O'Flynn' it would become 'Liam O\'Flynn'.

Sincerely,
**Liam O'Flynn**
