### PR TITLE
Make message textbox readonly when a chat message is sent

### DIFF
--- a/src/js/PusherChatWidget.js
+++ b/src/js/PusherChatWidget.js
@@ -117,7 +117,7 @@ PusherChatWidget.prototype._sendChatButtonClicked = function() {
 PusherChatWidget.prototype._sendChatMessage = function(data) {
   var self = this;
   
-  this._messageInputEl.attr('readonly');
+  this._messageInputEl.attr('readonly', 'readonly');
   $.ajax({
     url: this.settings.chatEndPoint,
     type: 'post',


### PR DESCRIPTION
Fixes #2.
A small issue fix.
Makes the message textbox `readonly`instead of getting the value of the `readonly` attribute
