### PR TITLE
Node.js Gravatar-related crash

### DIFF
--- a/src/nodejs/Activity.js
+++ b/src/nodejs/Activity.js
@@ -31,7 +31,7 @@ var Activity = function(activityType, actionText, options, callback) {
     self.image.url = gravatar.url(self.options["email"], {s: 80, d: "mm", r: "g"});
     
     var profile = gravatar.get_profile(gravatar.profile_url(self.options.email), function(error, profile) {
-      if (profile.entry[0].displayName) {
+      if (profile.entry && profile.entry[0].displayName) {
         self.displayName = profile.entry[0].displayName;
       }
 


### PR DESCRIPTION
Node.js server crashes when provided email not associated with a Gravatar profile, when trying to access 'profile.entry'.
Quick fix to avoid the crash (the avatar then gets set to the Gravatar anonymous pic instead of the default).